### PR TITLE
Fix problem where ext-sockets won't compile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:8.3-cli-alpine3.19
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
-RUN apk add --no-cache git zip unzip zlib-dev libpng-dev libzip-dev
+RUN apk add --no-cache git zip unzip zlib-dev libpng-dev libzip-dev linux-headers
 
 RUN docker-php-ext-install zip \
     && docker-php-ext-install exif \


### PR DESCRIPTION
This problem is fixed by installing `linux-headers` manually, See https://github.com/php/php-src/issues/8681